### PR TITLE
feat: /viewemployees route added in frontend

### DIFF
--- a/backend/src/routes/employee.js
+++ b/backend/src/routes/employee.js
@@ -3,6 +3,7 @@ const { requireAuth } = require("../../config/authJwt");
 
 module.exports = (router) => {
   router.route("/employees").get(requireAuth, controller.showAll);
+  router.route("/employees/public").get(controller.showAll); // Public route without auth
   router.route("/terminated").get(requireAuth, controller.showAllTerminated);
   router.route("/managers").get(requireAuth, controller.showManagers);
   router.route("/employees/:id").post(requireAuth, controller.showOne);
@@ -17,32 +18,18 @@ module.exports = (router) => {
   router.route("/employees/manager/none").get(requireAuth, controller.showEmployeeWithNoManager);
   router.route("/employees/manager/list").get(requireAuth, controller.showManagers);
   // Statistics/summary routes
-  router
-    .route("/employees/summaries/departments")
-    .get(requireAuth, controller.summarizeByDepartments);
-  router
-    .route("/employees/summaries/jobtitles")
-    .get(requireAuth, controller.summarizeByJobTitles);
+  router.route("/employees/summaries/departments").get(requireAuth, controller.summarizeByDepartments);
+  router.route("/employees/summaries/jobtitles").get(requireAuth, controller.summarizeByJobTitles);
 
-  router
-    .route("/employees/summaries/nationalities")
-    .get(requireAuth, controller.summarizeByNationalities);
+  router.route("/employees/summaries/nationalities").get(requireAuth, controller.summarizeByNationalities);
 
-  router
-    .route("/employees/summaries/locations")
-    .get(requireAuth, controller.summarizeByLocations);
+  router.route("/employees/summaries/locations").get(requireAuth, controller.summarizeByLocations);
   // endpoint for chart
-  router
-    .route("/employees/summaries/departments/chartdata")
-    .get(requireAuth, controller.summarizeByDepartmentsChartData);
+  router.route("/employees/summaries/departments/chartdata").get(requireAuth, controller.summarizeByDepartmentsChartData);
 
-  router
-    .route("/employees/summaries/headcounts/:year")
-    .get(requireAuth, controller.summarizeByHeadcounts);
+  router.route("/employees/summaries/headcounts/:year").get(requireAuth, controller.summarizeByHeadcounts);
 
   // Bulk change routes
-  router
-    .route("/employees/change/department")
-    .post(requireAuth, controller.changeDepartment);
+  router.route("/employees/change/department").post(requireAuth, controller.changeDepartment);
   router.route("/employees/change/job").post(requireAuth, controller.changeJob);
 };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,20 +7,21 @@ import CompleteSignup from "./components/LoginComponents/CompleteSignupPage.js";
 // import OffboardingPage from "./components/OffboardingComponents/OffboardingPage.jsx";
 import EmployeeOnboarding from "./containers/EmployeeOnboarding.js";
 import ErrorPage from "./components/Error/ErrorPage.jsx";
-
+import ViewEmployees from "./components/ViewEmployees/ViewEmployees.jsx";
 
 function App() {
-     return (
+  return (
     <StateProvider>
-       <Routes>
+      <Routes>
         <Route path="/" element={<LandingPage />} />
         <Route path="/onboarding" element={<EmployeeOnboarding />} />
         <Route path="/resetpassword/:id" element={<SetNewPasswordPage />} />
         <Route path="/complete-signup/:token" element={<CompleteSignup />} />
         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/viewemployees" element={<ViewEmployees />} />
         {/* <Route path="/off-boarding/:token" element={<OffboardingPage />} /> */}
         <Route path="*" element={<ErrorPage />} />
-      </Routes> 
+      </Routes>
     </StateProvider>
   );
 }

--- a/frontend/src/components/ViewEmployees/ViewEmployees.css
+++ b/frontend/src/components/ViewEmployees/ViewEmployees.css
@@ -1,0 +1,595 @@
+/* Modern Minimal Profile Cards Design */
+.view-employees-container {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f7fafc 0%, #edf2f7 100%);
+  position: relative;
+  padding: 0;
+  margin: 0;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+/* Profile Card Wrapper for positioning */
+.profile-card-wrapper {
+  position: relative;
+  margin-top: 40px; /* Space for half-overlapping avatar */
+}
+
+/* Profile Avatar Overlapping Effect */
+.profile-avatar {
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+
+.profile-card-wrapper:hover .profile-avatar {
+  transform: translateX(-50%) scale(1.1) !important;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2) !important;
+}
+
+/* Profile Card Styling */
+.profile-card {
+  position: relative;
+  overflow: visible !important;
+}
+
+/* Post Badge Styling */
+.post-badge {
+  animation: slideInFromRight 0.6s ease-out;
+}
+
+@keyframes slideInFromRight {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .profile-card-wrapper {
+    margin-top: 30px;
+  }
+
+  .profile-avatar {
+    width: 70px !important;
+    height: 70px !important;
+    top: -35px !important;
+    font-size: 1.5rem !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .view-employees-container .MuiContainer-root {
+    padding-left: 1rem !important;
+    padding-right: 1rem !important;
+  }
+
+  .profile-card-wrapper {
+    margin-top: 25px;
+  }
+
+  .profile-avatar {
+    width: 60px !important;
+    height: 60px !important;
+    top: -30px !important;
+    font-size: 1.25rem !important;
+  }
+}
+
+/* Loading and Error States */
+.view-employees-container .MuiCircularProgress-root {
+  color: #667eea !important;
+}
+
+.view-employees-container .MuiAlert-root {
+  border-radius: 12px !important;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08) !important;
+}
+
+/* Grid Spacing Optimization */
+.view-employees-container .MuiGrid-container {
+  margin-top: 0 !important;
+}
+
+.view-employees-container .MuiGrid-item {
+  padding-top: 0 !important;
+}
+
+/* Card Hover Animation Enhancement */
+.profile-card {
+  cursor: pointer;
+}
+
+.profile-card-wrapper:hover .profile-card {
+  border-color: #667eea !important;
+}
+
+/* Typography Refinements */
+.view-employees-container .MuiTypography-h6 {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif !important;
+  letter-spacing: -0.025em !important;
+}
+
+.view-employees-container .MuiTypography-body2 {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif !important;
+  letter-spacing: -0.01em !important;
+}
+
+/* Visual Hierarchy Enhancement */
+.profile-card .MuiBox-root {
+  position: relative;
+}
+
+/* Focus and Accessibility */
+.profile-card:focus-within {
+  outline: 2px solid #667eea;
+  outline-offset: 2px;
+}
+
+/* Animation for cards appearing */
+.profile-card-wrapper {
+  animation: fadeInUp 0.6s ease-out forwards;
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+.profile-card-wrapper:nth-child(1) {
+  animation-delay: 0.1s;
+}
+.profile-card-wrapper:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.profile-card-wrapper:nth-child(3) {
+  animation-delay: 0.3s;
+}
+.profile-card-wrapper:nth-child(4) {
+  animation-delay: 0.4s;
+}
+.profile-card-wrapper:nth-child(5) {
+  animation-delay: 0.5s;
+}
+.profile-card-wrapper:nth-child(6) {
+  animation-delay: 0.6s;
+}
+.profile-card-wrapper:nth-child(7) {
+  animation-delay: 0.7s;
+}
+.profile-card-wrapper:nth-child(8) {
+  animation-delay: 0.8s;
+}
+
+@keyframes fadeInUp {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.loading-spinner {
+  width: 60px;
+  height: 60px;
+  border: 4px solid rgba(102, 126, 234, 0.2);
+  border-top: 4px solid #667eea;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 1.5rem;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-content h2 {
+  color: #1a1a1a;
+  margin: 0 0 1rem;
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+.loading-content p,
+.error-content p {
+  color: #6b7280;
+  margin: 0;
+  font-size: 1rem;
+}
+
+.error-content {
+  border: 2px solid rgba(239, 68, 68, 0.2);
+}
+
+.error-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.error-content h3 {
+  color: #dc2626;
+  margin: 0 0 1rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+/* Header Section */
+.header-section {
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  border-radius: 24px;
+  padding: 3rem;
+  margin-bottom: 3rem;
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
+}
+
+.main-title {
+  font-size: 3.5rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin: 0 0 1rem;
+  line-height: 1.2;
+}
+
+.main-subtitle {
+  font-size: 1.25rem;
+  color: #6b7280;
+  margin: 0 0 2rem;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.6;
+  font-weight: 400;
+}
+
+.team-stats {
+  margin-top: 2rem;
+}
+
+.stat-badge {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  padding: 0.75rem 1.5rem;
+  border-radius: 50px;
+  font-weight: 600;
+  font-size: 1rem;
+  display: inline-block;
+  box-shadow: 0 8px 25px rgba(102, 126, 234, 0.3);
+  transition: all 0.3s ease;
+}
+
+.stat-badge:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 35px rgba(102, 126, 234, 0.4);
+}
+
+/* Employee Cards Grid */
+.employees-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 2rem;
+  margin-bottom: 3rem;
+}
+
+.employee-card {
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  border-radius: 24px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  min-height: 400px;
+  display: flex;
+  flex-direction: column;
+}
+
+.employee-card:hover {
+  transform: translateY(-12px) scale(1.02);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+}
+
+.employee-card:hover .employee-avatar .avatar-placeholder,
+.employee-card:hover .employee-avatar img {
+  transform: scale(1.1);
+}
+
+.department-bar {
+  height: 6px;
+  background: linear-gradient(90deg, var(--dept-color), var(--dept-color-light));
+}
+
+.card-content {
+  padding: 2rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Avatar Section */
+.employee-avatar {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.employee-avatar img,
+.avatar-placeholder {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+}
+
+.employee-avatar img {
+  object-fit: cover;
+  border: 4px solid rgba(255, 255, 255, 0.8);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+}
+
+.avatar-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 2.5rem;
+  font-weight: 600;
+  margin: 0 auto;
+  text-transform: uppercase;
+  border: 4px solid rgba(255, 255, 255, 0.8);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
+}
+
+/* Employee Info */
+.employee-info {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.employee-name {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin: 0 0 0.5rem;
+  line-height: 1.2;
+}
+
+.employee-position {
+  font-size: 1rem;
+  color: #6b7280;
+  margin: 0;
+  font-weight: 500;
+}
+
+.divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(0, 0, 0, 0.1), transparent);
+  margin: 1.5rem 0;
+}
+
+/* Employee Details */
+.employee-details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.detail-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+}
+
+.detail-icon {
+  font-size: 1.2rem;
+  width: 20px;
+  text-align: center;
+}
+
+.detail-text {
+  color: #4b5563;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.department-chip-container {
+  display: flex;
+  justify-content: center;
+  margin-top: auto;
+  padding-top: 1rem;
+}
+
+.department-chip {
+  padding: 0.5rem 1rem;
+  border-radius: 50px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border: 1px solid;
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+
+.department-chip:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+/* Stats Footer */
+.stats-footer {
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  border-radius: 24px;
+  padding: 2.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.1);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2rem;
+}
+
+.stat-item {
+  text-align: center;
+  padding: 1rem;
+}
+
+.stat-number {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #667eea;
+  margin-bottom: 0.5rem;
+  line-height: 1;
+}
+
+.stat-label {
+  color: #6b7280;
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Animations */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-in {
+  animation: fadeIn 0.8s ease-out forwards;
+}
+
+.fade-in-up {
+  opacity: 0;
+  animation: fadeInUp 0.8s ease-out forwards;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .container {
+    padding: 2rem 1rem;
+  }
+
+  .main-title {
+    font-size: 2.5rem;
+  }
+
+  .main-subtitle {
+    font-size: 1.1rem;
+  }
+
+  .employees-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .employee-card {
+    min-height: 350px;
+  }
+
+  .card-content {
+    padding: 1.5rem;
+  }
+
+  .employee-avatar img,
+  .avatar-placeholder {
+    width: 80px;
+    height: 80px;
+  }
+
+  .avatar-placeholder {
+    font-size: 2rem;
+  }
+
+  .employee-name {
+    font-size: 1.3rem;
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
+  }
+
+  .stat-number {
+    font-size: 2rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .header-section {
+    padding: 2rem 1.5rem;
+  }
+
+  .main-title {
+    font-size: 2rem;
+  }
+
+  .main-subtitle {
+    font-size: 1rem;
+  }
+
+  .card-content {
+    padding: 1rem;
+  }
+
+  .employee-card {
+    min-height: 320px;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .stats-footer {
+    padding: 1.5rem;
+  }
+}
+
+/* Custom Scrollbar */
+.view-employees-container::-webkit-scrollbar {
+  width: 8px;
+}
+
+.view-employees-container::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}
+
+.view-employees-container::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+}
+
+.view-employees-container::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.5);
+}

--- a/frontend/src/components/ViewEmployees/ViewEmployees.jsx
+++ b/frontend/src/components/ViewEmployees/ViewEmployees.jsx
@@ -1,0 +1,366 @@
+import React, { useState, useEffect } from "react";
+import { Box, Card, Typography, Avatar, Grid, CircularProgress, Container, Stack, Alert, Chip } from "@mui/material";
+import "./ViewEmployees.css";
+
+const BASE_URL = require("../../assets/FetchServices/BaseUrl.json").value;
+
+const ViewEmployees = () => {
+  const [employees, setEmployees] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // Position hierarchy for sorting
+  const getPositionRank = (position) => {
+    if (!position) return 999;
+    const pos = position.toLowerCase();
+    if (pos.includes("professor")) return 1;
+    if (pos.includes("associate")) return 2;
+    if (pos.includes("assistant")) return 3;
+    if (pos.includes("staff")) return 4;
+    return 5;
+  };
+
+  // Post highlighting - important posts to highlight
+  const isHighlightedPost = (post) => {
+    if (!post) return false;
+    const p = post.toLowerCase();
+    return ["hod", "dhod", "head", "director", "dean", "principal"].includes(p);
+  };
+
+  // Group employees by position
+  const groupEmployeesByPosition = (employeeList) => {
+    const groups = {};
+
+    employeeList.forEach((employee) => {
+      const position = employee.position || "Other";
+      if (!groups[position]) {
+        groups[position] = [];
+      }
+      groups[position].push(employee);
+    });
+
+    // Define position hierarchy order (exact matching)
+    const positionOrder = [
+      "Professor",
+      "Associate Professor",
+      "Assistant Professor",
+      "Lecturer",
+      "Senior Instructor",
+      "Instructor",
+      "Staff",
+    ];
+
+    // Sort groups by hierarchy and then sort employees within each group
+    const sortedGroups = {};
+
+    // First, add positions in the specified order
+    positionOrder.forEach((position) => {
+      if (groups[position]) {
+        // Sort employees within group by highlighted posts first
+        sortedGroups[position] = groups[position].sort((a, b) => {
+          const aHighlighted = isHighlightedPost(a.post);
+          const bHighlighted = isHighlightedPost(b.post);
+
+          if (aHighlighted && !bHighlighted) return -1;
+          if (!aHighlighted && bHighlighted) return 1;
+          return 0;
+        });
+        delete groups[position];
+      }
+    });
+
+    // Add any remaining positions not covered by the hierarchy at the end
+    Object.keys(groups).forEach((position) => {
+      if (groups[position]) {
+        sortedGroups[position] = groups[position].sort((a, b) => {
+          const aHighlighted = isHighlightedPost(a.post);
+          const bHighlighted = isHighlightedPost(b.post);
+
+          if (aHighlighted && !bHighlighted) return -1;
+          if (!aHighlighted && bHighlighted) return 1;
+          return 0;
+        });
+      }
+    });
+
+    return sortedGroups;
+  };
+
+  useEffect(() => {
+    const fetchEmployees = async () => {
+      try {
+        const response = await fetch(`${BASE_URL}/api/employees/public`);
+        if (!response.ok) {
+          throw new Error("Failed to fetch employees");
+        }
+        const data = await response.json();
+        const groupedEmployees = groupEmployeesByPosition(data);
+        setEmployees(groupedEmployees);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchEmployees();
+  }, []);
+
+  if (loading) {
+    return (
+      <Box className="view-employees-container" display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
+        <Stack alignItems="center" spacing={3}>
+          <CircularProgress size={60} thickness={4} sx={{ color: "#667eea" }} />
+          <Typography variant="h4" fontWeight={600} sx={{ color: "#1a202c" }}>
+            Loading...
+          </Typography>
+          <Typography variant="body1" sx={{ color: "#4a5568" }}>
+            Please wait while we fetch employee information.
+          </Typography>
+        </Stack>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box className="view-employees-container">
+        <Container maxWidth="md" sx={{ pt: 4 }}>
+          <Alert severity="error" sx={{ borderRadius: 3 }}>
+            <Typography variant="h6">Error loading employees</Typography>
+            <Typography variant="body2">{error}</Typography>
+          </Alert>
+        </Container>
+      </Box>
+    );
+  }
+
+  return (
+    <Box className="view-employees-container">
+      <Container maxWidth="lg" sx={{ py: 6 }}>
+        {/* Header Section */}
+        <Box textAlign="center" mb={8}>
+          <Typography
+            variant="h2"
+            component="h1"
+            fontWeight={700}
+            sx={{
+              color: "#1a202c",
+              mb: 2,
+              fontSize: { xs: "2.5rem", md: "3.5rem" },
+            }}
+          >
+            Faculty
+          </Typography>
+          <Typography
+            variant="h6"
+            sx={{
+              color: "#4a5568",
+              maxWidth: "600px",
+              mx: "auto",
+              fontSize: "1.125rem",
+              fontWeight: 400,
+            }}
+          >
+            Department of Electronics and Computer Engineering
+          </Typography>
+        </Box>
+
+        {/* Employee Cards Grouped by Position */}
+        {Object.entries(employees).map(([position, employeeList]) => (
+          <Box key={position} mb={8}>
+            {/* Position Section Header */}
+            <Box sx={{ textAlign: "center", mb: 4, position: "relative" }}>
+              <Typography
+                variant="h4"
+                component="h2"
+                fontWeight={700}
+                sx={{
+                  color: "#1a202c",
+                  fontSize: "2rem",
+                  display: "inline-block",
+                  position: "relative",
+                  "&::after": {
+                    content: '""',
+                    position: "absolute",
+                    bottom: "-8px",
+                    left: "50%",
+                    transform: "translateX(-50%)",
+                    width: "80px",
+                    height: "3px",
+                    backgroundColor: "#667eea",
+                    borderRadius: "2px",
+                  },
+                }}
+              >
+                {position}
+              </Typography>
+              <Typography
+                component="span"
+                sx={{
+                  ml: 2,
+                  fontSize: "1rem",
+                  color: "#667eea",
+                  fontWeight: 500,
+                }}
+              >
+                ({employeeList.length})
+              </Typography>
+            </Box>
+
+            {/* Employee Cards Grid for this position */}
+            <Grid container spacing={6}>
+              {employeeList.map((employee) => (
+                <Grid item xs={12} sm={6} md={4} key={employee.empId}>
+                  <Box
+                    className="profile-card-wrapper"
+                    sx={{
+                      mt: 10,
+                      "&:hover": {
+                        "& .profile-avatar": {
+                          transform: "translateX(-50%) translateY(-4px)",
+                        },
+                      },
+                    }}
+                  >
+                    {/* Highlighted Post Badge */}
+                    {isHighlightedPost(employee.post) && (
+                      <Chip
+                        label={employee.post}
+                        className="post-badge"
+                        sx={{
+                          position: "absolute",
+                          top: -10,
+                          right: 16,
+                          zIndex: 3,
+                          bgcolor: "#e53e3e",
+                          color: "white",
+                          fontWeight: 700,
+                          fontSize: "0.75rem",
+                          textTransform: "uppercase",
+                          letterSpacing: "0.5px",
+                          "&:hover": {
+                            bgcolor: "#c53030",
+                          },
+                        }}
+                      />
+                    )}
+
+                    {/* Profile Picture - Half Above Card */}
+                    <Avatar
+                      src={employee.photo}
+                      className="profile-avatar"
+                      sx={{
+                        width: 100,
+                        height: 100,
+                        position: "absolute",
+                        top: -50,
+                        left: "50%",
+                        transform: "translateX(-50%)",
+                        zIndex: 2,
+                        border: "4px solid white",
+                        boxShadow: "0 8px 24px rgba(0, 0, 0, 0.15)",
+                        bgcolor: "#667eea",
+                        fontSize: "2rem",
+                        fontWeight: 600,
+                        color: "white",
+                      }}
+                    >
+                      {employee.preferredName?.charAt(0) || employee.firstName?.charAt(0) || "?"}
+                    </Avatar>
+
+                    {/* Card Content */}
+                    <Card
+                      className="profile-card"
+                      sx={{
+                        borderRadius: 4,
+                        overflow: "visible",
+                        boxShadow: "0 4px 20px rgba(0, 0, 0, 0.08)",
+                        transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+                        bgcolor: "white",
+                        border: "1px solid #e2e8f0",
+                        "&:hover": {
+                          transform: "translateY(-4px)",
+                          boxShadow: "0 12px 40px rgba(0, 0, 0, 0.15)",
+                        },
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          pt: 7,
+                          pb: 5,
+                          px: 4,
+                          textAlign: "center",
+                          minHeight: 200,
+                        }}
+                      >
+                        {/* Employee Name */}
+                        <Typography
+                          variant="h6"
+                          component="h3"
+                          fontWeight={600}
+                          sx={{
+                            color: "#1a202c",
+                            mb: 1,
+                            fontSize: "1.25rem",
+                            lineHeight: 1.3,
+                            textAlign: "center",
+                          }}
+                        >
+                          {employee.preferredName || `${employee.firstName} ${employee.lastName}`}
+                        </Typography>
+
+                        {/* Position - Only show once, prioritize important info */}
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            color: "#667eea",
+                            fontWeight: 500,
+                            mb: 1,
+                            fontSize: "0.95rem",
+                            textAlign: "center",
+                          }}
+                        >
+                          {employee.position}
+                        </Typography>
+
+                        {/* Post - Show right after position if not highlighted */}
+                        {employee.post && !isHighlightedPost(employee.post) && (
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              color: "#4a5568",
+                              fontWeight: 500,
+                              fontSize: "0.875rem",
+                              textAlign: "center",
+                              mb: 2,
+                            }}
+                          >
+                            {employee.post}
+                          </Typography>
+                        )}
+
+                        {/* Separator line for future content */}
+                        <Box
+                          sx={{
+                            mt: 2,
+                            pt: 2,
+                            borderTop: "1px solid #e2e8f0",
+                          }}
+                        >
+                          {/* Future content will go here */}
+                        </Box>
+                      </Box>
+                    </Card>
+                  </Box>
+                </Grid>
+              ))}
+            </Grid>
+          </Box>
+        ))}
+      </Container>
+    </Box>
+  );
+};
+
+export default ViewEmployees;

--- a/frontend/src/components/ViewEmployees/index.js
+++ b/frontend/src/components/ViewEmployees/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ViewEmployees";


### PR DESCRIPTION
### rn, shows something like this:
<img width="1757" height="952" alt="image" src="https://github.com/user-attachments/assets/0bcf1395-6ba5-4332-9a54-7273592c5a13" />

I've designed it so that main posts like HOD and DHOD are visually emphasized, other posts are just placed below positions.


- The campus logo would probably look better at the top-left or top-right corner.
- Also, the blank space below the line in each card is reserved for the field of interest.




