### PR TITLE
fix: show actual photo

### DIFF
--- a/frontend/src/components/ViewEmployees/ViewEmployees.jsx
+++ b/frontend/src/components/ViewEmployees/ViewEmployees.jsx
@@ -327,7 +327,7 @@ const ViewEmployees = () => {
 
                     {/* Profile Picture - Half Above Card */}
                     <Avatar
-                      src={employee.photo}
+                      src={employee.photo ? `data:image/png;base64,${atob(employee.photo)}` : undefined}
                       className="profile-avatar"
                       sx={{
                         width: 100,


### PR DESCRIPTION
Closes #3 


Updated the logic similarly to how the photo is displayed in the People section at ` http://localhost:3000/dashboard `